### PR TITLE
fix: separate client-only events

### DIFF
--- a/forge/src/main/java/net/anweisen/notenoughpots/client/NotEnoughPotsForgeClient.java
+++ b/forge/src/main/java/net/anweisen/notenoughpots/client/NotEnoughPotsForgeClient.java
@@ -9,6 +9,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.StemBlock;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RegisterColorHandlersEvent;
 import net.minecraftforge.client.event.RegisterNamedRenderTypesEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -18,7 +19,11 @@ import net.minecraftforge.fml.common.Mod;
  * @author anweisen | https://github.com/anweisen
  * @since 1.0
  */
-@Mod.EventBusSubscriber(modid = Constants.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
+@Mod.EventBusSubscriber(
+  value = Dist.CLIENT,
+  modid = Constants.MOD_ID,
+  bus = Mod.EventBusSubscriber.Bus.MOD
+)
 public class NotEnoughPotsForgeClient {
 
   @SubscribeEvent

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Important Notes:
 # Every field you add must be added to the root build.gradle expandProps map.
 # Project
-version=1.1.1
+version=1.1.2
 group=net.anweisen
 java_version=21
 # Common

--- a/neoforge/src/main/java/net/anweisen/notenoughpots/client/NotEnoughPotsNeoForgeClient.java
+++ b/neoforge/src/main/java/net/anweisen/notenoughpots/client/NotEnoughPotsNeoForgeClient.java
@@ -4,12 +4,10 @@ import net.anweisen.notenoughpots.Constants;
 import net.anweisen.notenoughpots.NotEnoughPotsBlockType;
 import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.color.block.BlockColors;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.Sheets;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.StemBlock;
+import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.RegisterColorHandlersEvent;
@@ -19,7 +17,11 @@ import net.neoforged.neoforge.client.event.RegisterNamedRenderTypesEvent;
  * @author anweisen | https://github.com/anweisen
  * @since 1.0
  */
-@EventBusSubscriber(modid = Constants.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(
+  value = Dist.CLIENT,
+  modid = Constants.MOD_ID,
+  bus = EventBusSubscriber.Bus.MOD
+)
 public class NotEnoughPotsNeoForgeClient {
 
   @SubscribeEvent


### PR DESCRIPTION
Resolves issue #1 , by separating client-only events and preventing them from being loaded on dedicated server environments 