### PR TITLE
fix: remove locale dependence for ids

### DIFF
--- a/common/src/main/java/net/anweisen/notenoughpots/NotEnoughPotsBlockType.java
+++ b/common/src/main/java/net/anweisen/notenoughpots/NotEnoughPotsBlockType.java
@@ -2,6 +2,7 @@ package net.anweisen.notenoughpots;
 
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import java.util.Locale;
 
 /**
  * @author anweisen | https://github.com/anweisen
@@ -53,7 +54,8 @@ public enum NotEnoughPotsBlockType implements IPottedBlockType {
 
   NotEnoughPotsBlockType(Block flower) {
     this.flower = flower;
-    this.name = this.name().toLowerCase();
+    // using Locale.ROOT fixes https://github.com/anweisemods/NotEnoughPots/issues/4
+    this.name = this.name().toLowerCase(Locale.ROOT);
   }
 
   @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Important Notes:
 # Every field you add must be added to the root build.gradle expandProps map.
 # Project
-version=1.3
+version=1.3.1
 group=net.anweisen
 java_version=21
 # Common


### PR DESCRIPTION
This PR aims to resolve #4.

For the resource locations (IDs) of the blocks, the enum names, transformed to a lowercase String, were used.
This was done using only `.toLowerCase()` which has edge cases I was not aware of, resulting in illegal IDs which crash the game upon start.

> Non [a-z0-9/._-] character in path of location: notenoughpots:potted_l\u0131lac

In this specific report, the use of locale `tr_TR` (Turkish language), which was not tested for, resulted in a locale-sensitive unexpected result.

The `I` (capital letter I) resulted in a `ı` `\u0131` (Latin small letter dotless i) rather than an `i` (small letter i)

It is recommended to use `Locale.ROOT` for locale independent operations to ensure consistency over all systems.