### PR TITLE
fix: add loot tables

### DIFF
--- a/common/src/main/java/net/anweisen/notenoughpots/IPottedBlockType.java
+++ b/common/src/main/java/net/anweisen/notenoughpots/IPottedBlockType.java
@@ -1,8 +1,14 @@
 package net.anweisen.notenoughpots;
 
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.FlowerPotBlock;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.material.PushReaction;
+
+import java.util.Optional;
 
 /**
  * @author anweisen | https://github.com/anweisen
@@ -35,9 +41,38 @@ public interface IPottedBlockType {
    *
    * @see #getFlowerBlock()
    */
-  default Block createPottedFlowerBlock() {
+  default Block createPottedFlowerBlock(String modId) {
     // BlockBehaviour.Properties.ofFullCopy(Blocks.FLOWER_POT) does no longer work in 1.21.2+
-    return new FlowerPotBlock(this.getFlowerBlock(), Blocks.FLOWER_POT.properties());
+    // Apply loot table via custom properties (#6)
+    return new FlowerPotBlock(this.getFlowerBlock(), createPottedFlowerBlockProperties(modId));
+  }
+
+  /**
+   * Creates the block properties for the potted block.
+   * Copied from vanilla FLOWER_POT properties, applies custom id and loot table.
+   *
+   * @param modId The mod id to use for the resource location
+   * @return The block properties for the potted block
+   * @since 1.4.1
+   */
+  default BlockBehaviour.Properties createPottedFlowerBlockProperties(String modId) {
+    // Copied from vanilla FLOWER_POT properties
+    return BlockBehaviour.Properties.of().instabreak().noOcclusion().pushReaction(PushReaction.DESTROY)
+      .setId(ResourceKey.create(Registries.BLOCK, createResourceLocation(modId)))
+      .overrideLootTable(Optional.of(ResourceKey.create(Registries.LOOT_TABLE, createResourceLocation(modId))));
+  }
+
+  /**
+   * Creates a resource location for the potted block based on the mod id and the internal name.
+   * Used for registering the block and its loot table.
+   *
+   * @param modId The mod id to use for the resource location
+   * @return The created resource location
+   * @since 1.4.1
+   * @see #getName()
+   */
+  default ResourceLocation createResourceLocation(String modId) {
+    return ResourceLocation.fromNamespaceAndPath(modId, this.getName());
   }
 
 }

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_beetroots.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_beetroots.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:beetroot_seeds"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_big_dripleaf.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_big_dripleaf.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:big_dripleaf"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_bush.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_bush.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:bush"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_cactus_flower.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_cactus_flower.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:cactus_flower"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_carrots.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_carrots.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:carrot"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_cave_vines.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_cave_vines.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:glow_berries"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_chorus_flower.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_chorus_flower.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:chorus_flower"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_chorus_plant.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_chorus_plant.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:chorus_plant"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_cocoa.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_cocoa.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:cocoa_beans"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_firefly_bush.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_firefly_bush.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:firefly_bush"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_hanging_roots.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_hanging_roots.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:hanging_roots"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_large_fern.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_large_fern.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:large_fern"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_lilac.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_lilac.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:lilac"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_melon_block.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_melon_block.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:melon"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_melon_stem.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_melon_stem.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:melon_seeds"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_nether_sprouts.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_nether_sprouts.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:nether_sprouts"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_nether_wart.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_nether_wart.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:nether_wart"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_pale_hanging_moss.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_pale_hanging_moss.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:pale_hanging_moss"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_peony.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_peony.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:peony"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_pitcher_crop.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_pitcher_crop.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:pitcher_pod"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_pitcher_plant.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_pitcher_plant.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:pitcher_plant"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_potatoes.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_potatoes.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:potato"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_pumpkin_block.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_pumpkin_block.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:pumpkin"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_pumpkin_stem.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_pumpkin_stem.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:pumpkin_seeds"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_rose_bush.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_rose_bush.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:rose_bush"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_sea_pickle.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_sea_pickle.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:sea_pickle"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_short_dry_grass.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_short_dry_grass.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:short_dry_grass"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_short_grass.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_short_grass.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:short_grass"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_small_dripleaf.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_small_dripleaf.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:small_dripleaf"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_spore_blossom.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_spore_blossom.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:spore_blossom"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_sugar_cane.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_sugar_cane.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:sugar_cane"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_sunflower.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_sunflower.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:sunflower"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_sweet_berry_bush.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_sweet_berry_bush.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:sweet_berries"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_tall_dry_grass.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_tall_dry_grass.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:tall_dry_grass"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_tall_grass.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_tall_grass.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:tall_grass"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_torchflower_seeds.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_torchflower_seeds.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:torchflower_seeds"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_twisting_vines.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_twisting_vines.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:twisting_vines"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_weeping_vines.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_weeping_vines.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:weeping_vines"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/common/src/main/resources/data/notenoughpots/loot_table/potted_wheat.json
+++ b/common/src/main/resources/data/notenoughpots/loot_table/potted_wheat.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:wheat_seeds"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'multiloader-loader'
 	id 'fabric-loom'
 }
+
 dependencies {
 	minecraft "com.mojang:minecraft:${minecraft_version}"
 	mappings loom.layered {
@@ -27,6 +28,19 @@ loom {
 			ideConfigGenerated(true)
 			runDir('runs/client')
 		}
+        datagen {
+            server() // Explicitly call the server environment method
+
+            name "Data Generation"
+            vmArg "-Dfabric-api.datagen"
+            vmArg "-Dfabric-api.datagen.output-dir=${file("src/main/generated")}"
+            vmArg "-Dfabric-api.datagen.modid=notenoughpots"
+
+            runDir "build/datagen"
+
+            // This ensures IntelliJ creates the run config file correctly
+            ideConfigGenerated = true
+        }
 		server {
 			server()
 			setConfigName('Fabric Server')

--- a/fabric/src/main/java/net/anweisen/notenoughpots/datagen/NotEnoughPotsFabricDataGenerator.java
+++ b/fabric/src/main/java/net/anweisen/notenoughpots/datagen/NotEnoughPotsFabricDataGenerator.java
@@ -1,0 +1,14 @@
+package net.anweisen.notenoughpots.datagen;
+
+import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+
+public class NotEnoughPotsFabricDataGenerator implements DataGeneratorEntrypoint {
+
+  @Override
+  public void onInitializeDataGenerator(FabricDataGenerator fabricDataGenerator) {
+    FabricDataGenerator.Pack pack = fabricDataGenerator.createPack();
+    pack.addProvider(NotEnoughPotsLootTableProvider::new);
+  }
+
+}

--- a/fabric/src/main/java/net/anweisen/notenoughpots/datagen/NotEnoughPotsLootTableProvider.java
+++ b/fabric/src/main/java/net/anweisen/notenoughpots/datagen/NotEnoughPotsLootTableProvider.java
@@ -1,0 +1,23 @@
+package net.anweisen.notenoughpots.datagen;
+
+import net.anweisen.notenoughpots.NotEnoughPotsBlockType;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricBlockLootTableProvider;
+import net.minecraft.core.HolderLookup;
+
+import java.util.concurrent.CompletableFuture;
+
+public class NotEnoughPotsLootTableProvider extends FabricBlockLootTableProvider {
+
+  protected NotEnoughPotsLootTableProvider(FabricDataOutput dataOutput, CompletableFuture<HolderLookup.Provider> registryLookup) {
+    super(dataOutput, registryLookup);
+  }
+
+  @Override
+  public void generate() {
+    for (var type : NotEnoughPotsBlockType.values()) {
+      add(type.findBlock(), block -> createPotFlowerItemTable(type.getFlowerBlock().asItem()));
+    }
+  }
+
+}

--- a/fabric/src/main/java/net/anweisen/notenoughpots/platform/FabricPlatformBridge.java
+++ b/fabric/src/main/java/net/anweisen/notenoughpots/platform/FabricPlatformBridge.java
@@ -3,7 +3,6 @@ package net.anweisen.notenoughpots.platform;
 import net.anweisen.notenoughpots.IPottedBlockType;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
 import java.util.EnumMap;
 import java.util.Map;
@@ -24,11 +23,11 @@ public class FabricPlatformBridge<T extends Enum<T> & IPottedBlockType> implemen
 
   @Override
   public void registerPottedBlock(T type) {
-    pottedBlocks.put(type, registerBuiltIn(type.getName(), type.createPottedFlowerBlock()));
+    pottedBlocks.put(type, registerBuiltIn(type));
   }
 
-  public Block registerBuiltIn(String name, Block block) {
-    return Registry.register(BuiltInRegistries.BLOCK, ResourceLocation.fromNamespaceAndPath(modId, name), block);
+  public Block registerBuiltIn(T type) {
+    return Registry.register(BuiltInRegistries.BLOCK, type.createResourceLocation(modId), type.createPottedFlowerBlock(modId));
   }
 
   @Override

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -20,6 +20,9 @@
     ],
     "client": [
       "net.anweisen.notenoughpots.client.NotEnoughPotsFabricClient"
+    ],
+    "fabric-datagen": [
+      "net.anweisen.notenoughpots.datagen.NotEnoughPotsFabricDataGenerator"
     ]
   },
   "mixins": [
@@ -31,8 +34,5 @@
     "fabric-api": "*",
     "minecraft": "${minecraft_version_range_fabric}",
     "java": ">=${java_version}"
-  },
-  "suggests": {
-    "another-mod": "*"
   }
 }

--- a/forge/src/main/java/net/anweisen/notenoughpots/NotEnoughPotsForgeMod.java
+++ b/forge/src/main/java/net/anweisen/notenoughpots/NotEnoughPotsForgeMod.java
@@ -14,7 +14,7 @@ public class NotEnoughPotsForgeMod {
 
   public NotEnoughPotsForgeMod(FMLJavaModLoadingContext context) {
     var eventBus = context.getModEventBus();
-    var bridge = new ForgePlatformBridge<>(eventBus, BLOCKS, NotEnoughPotsBlockType.class, NotEnoughPotsCommons.MOD_ID);
+    var bridge = new ForgePlatformBridge<>(NotEnoughPotsCommons.MOD_ID, eventBus, BLOCKS, NotEnoughPotsBlockType.class);
     NotEnoughPotsCommons.init(bridge);
   }
 }

--- a/forge/src/main/java/net/anweisen/notenoughpots/NotEnoughPotsForgeMod.java
+++ b/forge/src/main/java/net/anweisen/notenoughpots/NotEnoughPotsForgeMod.java
@@ -14,7 +14,7 @@ public class NotEnoughPotsForgeMod {
 
   public NotEnoughPotsForgeMod(FMLJavaModLoadingContext context) {
     var eventBus = context.getModEventBus();
-    var bridge = new ForgePlatformBridge<>(eventBus, BLOCKS, NotEnoughPotsBlockType.class);
+    var bridge = new ForgePlatformBridge<>(eventBus, BLOCKS, NotEnoughPotsBlockType.class, NotEnoughPotsCommons.MOD_ID);
     NotEnoughPotsCommons.init(bridge);
   }
 }

--- a/forge/src/main/java/net/anweisen/notenoughpots/platform/ForgePlatformBridge.java
+++ b/forge/src/main/java/net/anweisen/notenoughpots/platform/ForgePlatformBridge.java
@@ -20,11 +20,11 @@ public class ForgePlatformBridge<T extends Enum<T> & IPottedBlockType> implement
   private final IEventBus eventBus;
   private final DeferredRegister<Block> register;
 
-  public ForgePlatformBridge(IEventBus eventBus, DeferredRegister<Block> register, Class<T> enumClass, String modId) {
+  public ForgePlatformBridge(String modId, IEventBus eventBus, DeferredRegister<Block> register, Class<T> enumClass) {
+    this.modId = modId;
     this.eventBus = eventBus;
     this.register = register;
     this.pottedBlocks = new EnumMap<>(enumClass);
-    this.modId = modId;
   }
 
   @Override

--- a/forge/src/main/java/net/anweisen/notenoughpots/platform/ForgePlatformBridge.java
+++ b/forge/src/main/java/net/anweisen/notenoughpots/platform/ForgePlatformBridge.java
@@ -16,18 +16,20 @@ public class ForgePlatformBridge<T extends Enum<T> & IPottedBlockType> implement
 
   private final Map<T, RegistryObject<Block>> pottedBlocks;
 
+  private final String modId;
   private final IEventBus eventBus;
   private final DeferredRegister<Block> register;
 
-  public ForgePlatformBridge(IEventBus eventBus, DeferredRegister<Block> register, Class<T> enumClass) {
+  public ForgePlatformBridge(IEventBus eventBus, DeferredRegister<Block> register, Class<T> enumClass, String modId) {
     this.eventBus = eventBus;
     this.register = register;
     this.pottedBlocks = new EnumMap<>(enumClass);
+    this.modId = modId;
   }
 
   @Override
   public void registerPottedBlock(T type) {
-    pottedBlocks.put(type, register.register(type.getName(), type::createPottedFlowerBlock));
+    pottedBlocks.put(type, register.register(type.getName(), () -> type.createPottedFlowerBlock(modId)));
   }
 
   public void finishRegistration() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Important Notes:
 # Every field you add must be added to the root build.gradle expandProps map.
 # Project
-version=1.4
+version=1.4.1
 group=net.anweisen
 java_version=21
 # Common

--- a/neoforge/src/main/java/net/anweisen/notenoughpots/NotEnoughPotsNeoForgeMod.java
+++ b/neoforge/src/main/java/net/anweisen/notenoughpots/NotEnoughPotsNeoForgeMod.java
@@ -14,7 +14,7 @@ public class NotEnoughPotsNeoForgeMod {
   public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(Registries.BLOCK, NotEnoughPotsCommons.MOD_ID);
 
   public NotEnoughPotsNeoForgeMod(IEventBus eventBus) {
-    var bridge = new NeoForgePlatformBridge<>(eventBus, BLOCKS, NotEnoughPotsBlockType.class);
+    var bridge = new NeoForgePlatformBridge<>(eventBus, BLOCKS, NotEnoughPotsBlockType.class, NotEnoughPotsCommons.MOD_ID);
     NotEnoughPotsCommons.init(bridge);
   }
 }

--- a/neoforge/src/main/java/net/anweisen/notenoughpots/NotEnoughPotsNeoForgeMod.java
+++ b/neoforge/src/main/java/net/anweisen/notenoughpots/NotEnoughPotsNeoForgeMod.java
@@ -14,7 +14,7 @@ public class NotEnoughPotsNeoForgeMod {
   public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(Registries.BLOCK, NotEnoughPotsCommons.MOD_ID);
 
   public NotEnoughPotsNeoForgeMod(IEventBus eventBus) {
-    var bridge = new NeoForgePlatformBridge<>(eventBus, BLOCKS, NotEnoughPotsBlockType.class, NotEnoughPotsCommons.MOD_ID);
+    var bridge = new NeoForgePlatformBridge<>(NotEnoughPotsCommons.MOD_ID, eventBus, BLOCKS, NotEnoughPotsBlockType.class);
     NotEnoughPotsCommons.init(bridge);
   }
 }

--- a/neoforge/src/main/java/net/anweisen/notenoughpots/platform/NeoForgePlatformBridge.java
+++ b/neoforge/src/main/java/net/anweisen/notenoughpots/platform/NeoForgePlatformBridge.java
@@ -20,11 +20,11 @@ public class NeoForgePlatformBridge<T extends Enum<T> & IPottedBlockType> implem
   private final IEventBus eventBus;
   private final DeferredRegister<Block> register;
 
-  public NeoForgePlatformBridge(IEventBus eventBus, DeferredRegister<Block> register, Class<T> enumClass, String modId) {
+  public NeoForgePlatformBridge(String modId, IEventBus eventBus, DeferredRegister<Block> register, Class<T> enumClass) {
+    this.modId = modId;
     this.eventBus = eventBus;
     this.register = register;
     this.pottedBlocks = new EnumMap<>(enumClass);
-    this.modId = modId;
   }
 
   @Override

--- a/neoforge/src/main/java/net/anweisen/notenoughpots/platform/NeoForgePlatformBridge.java
+++ b/neoforge/src/main/java/net/anweisen/notenoughpots/platform/NeoForgePlatformBridge.java
@@ -16,18 +16,20 @@ public class NeoForgePlatformBridge<T extends Enum<T> & IPottedBlockType> implem
 
   private final Map<T, DeferredHolder<Block, Block>> pottedBlocks;
 
+  private final String modId;
   private final IEventBus eventBus;
   private final DeferredRegister<Block> register;
 
-  public NeoForgePlatformBridge(IEventBus eventBus, DeferredRegister<Block> register, Class<T> enumClass) {
+  public NeoForgePlatformBridge(IEventBus eventBus, DeferredRegister<Block> register, Class<T> enumClass, String modId) {
     this.eventBus = eventBus;
     this.register = register;
     this.pottedBlocks = new EnumMap<>(enumClass);
+    this.modId = modId;
   }
 
   @Override
   public void registerPottedBlock(T type) {
-    pottedBlocks.put(type, register.register(type.getName(), type::createPottedFlowerBlock));
+    pottedBlocks.put(type, register.register(type.getName(), () -> type.createPottedFlowerBlock(modId)));
   }
 
   public void finishRegistration() {


### PR DESCRIPTION
Aims to resolve #6 

Adds block drops for potted flowers with the correct items by providing loot tables for corresponding variants.
